### PR TITLE
ora -> goracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ supported out of the box:
 |------------------------------|---------------------------------------|
 | Microsoft SQL Server (mssql) | ms, sqlserver                         |
 | MySQL (mysql)                | my, mariadb, maria, percona, aurora   |
-| Oracle (ora)                 | or, oracle, oci8, oci                 |
+| Oracle (goracle)             | or, oracle, oci8, ora, oci, goracle   |
 | PostgreSQL (postgres)        | pg, postgresql, pgsql                 |
 | SQLite3 (sqlite3)            | sq, sqlite, file                      |
 |                              |                                       |
@@ -123,11 +123,12 @@ provides a standard way to parse/open respective database connection URLs.
 For reference, these are the following "expected" SQL drivers that would need
 to be imported:
 
+<<<<<<< HEAD
 | Database (driver)            | Package                                                                                     |
 |------------------------------|---------------------------------------------------------------------------------------------|
 | Microsoft SQL Server (mssql) | [github.com/denisenkom/go-mssqldb](https://github.com/denisenkom/go-mssqldb)                |
 | MySQL (mysql)                | [github.com/go-sql-driver/mysql](https://github.com/go-sql-driver/mysql)                    |
-| Oracle (ora)                 | [gopkg.in/rana/ora.v4](https://gopkg.in/rana/ora.v4)                                        |
+| Oracle (goracle)             | [gopkg.in/goracle.v2](https://gopkg.in/goracle.v2)                                          |
 | PostgreSQL (postgres)        | [github.com/lib/pq](https://github.com/lib/pq)                                              |
 | SQLite3 (sqlite3)            | [github.com/mattn/go-sqlite3](https://github.com/mattn/go-sqlite3)                          |
 |                              |                                                                                             |

--- a/dburl.go
+++ b/dburl.go
@@ -62,7 +62,7 @@
 //   -----------------------------|-------------------------------------------
 //   Microsoft SQL Server (mssql) | ms, sqlserver
 //   MySQL (mysql)                | my, mariadb, maria, percona, aurora
-//   Oracle (ora)                 | or, oracle, oci8, oci
+//   Oracle (goracle)             | or, oracle, oci8, ora, oci, goracle
 //   PostgreSQL (postgres)        | pg, postgresql, pgsql
 //   SQLite3 (sqlite3)            | sq, sqlite, file
 //   -----------------------------|-------------------------------------------
@@ -104,7 +104,7 @@
 //   -----------------------------|-------------------------------------------------
 //   Microsoft SQL Server (mssql) | github.com/denisenkom/go-mssqldb
 //   MySQL (mysql)                | github.com/go-sql-driver/mysql
-//   Oracle (ora)                 | gopkg.in/rana/ora.v4
+//   Oracle (goracle)             | gopkg.in/goracle.v2
 //   PostgreSQL (postgres)        | github.com/lib/pq
 //   SQLite3 (sqlite3)            | github.com/mattn/go-sqlite3
 //   -----------------------------|-------------------------------------------------

--- a/scheme.go
+++ b/scheme.go
@@ -54,7 +54,7 @@ func BaseSchemes() []Scheme {
 		// core databases
 		{"mssql", GenSQLServer, 0, false, []string{"sqlserver"}, ""},
 		{"mysql", GenMySQL, ProtoTCP | ProtoUDP | ProtoUnix, false, []string{"mariadb", "maria", "percona", "aurora"}, ""},
-		{"ora", GenOracle, 0, false, []string{"oracle", "oci8", "oci"}, ""},
+		{"goracle", GenOracle, 0, false, []string{"oracle", "oci8", "ora", "oci"}, ""},
 		{"postgres", GenPostgres, ProtoUnix, false, []string{"pg", "postgresql", "pgsql"}, ""},
 		{"sqlite3", GenOpaque, 0, true, []string{"sqlite", "file"}, ""},
 


### PR DESCRIPTION
goracle.v2 is a simpler, database/sql -only driver for Oracle, which is easier to install (no need for Oracle Instant Client for compiling, only at runtime).