### PR TITLE
Add "mylogin:" scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ supported out of the box:
 | MemSQL (memsql)              | me [mysql]                            |
 | TiDB (tidb)                  | ti [mysql]                            |
 | Vitess (vitess)              | vt [mysql]                            |
+| MySQL with ~/.mylogin.cnf (mylogin) | ml [mylogin]                     |
 |                              |                                       |
 | Google Spanner (spanner)     | gs, google, span (not yet public)     |
 |                              |                                       |
@@ -139,6 +140,7 @@ to be imported:
 | MemSQL (memsql)              | [github.com/go-sql-driver/mysql](https://github.com/go-sql-driver/mysql)                    |
 | TiDB (tidb)                  | [github.com/go-sql-driver/mysql](https://github.com/go-sql-driver/mysql)                    |
 | Vitess (vitess)              | [github.com/go-sql-driver/mysql](https://github.com/go-sql-driver/mysql)                    |
+| MySQL with ~/.mylogin.cnf (mylogin) | [github.com/dolmen-go/mylogin-driver/register](https://github.com/dolmen-go/mylogin-driver) |
 |                              |                                                                                             |
 | Google Spanner (spanner)     | github.com/xo/spanner (not yet public)                                                      |
 |                              |                                                                                             |

--- a/dburl_test.go
+++ b/dburl_test.go
@@ -44,6 +44,7 @@ func TestBadParse(t *testing.T) {
 		{`sf://`, ErrMissingHost},
 		{`snowflake://account`, ErrMissingPath},
 		{`sf://account`, ErrMissingPath},
+		{`mylogin+tcp://`, ErrInvalidTransportProtocol},
 	}
 
 	for i, test := range tests {
@@ -140,6 +141,15 @@ func TestParse(t *testing.T) {
 		{`sf://user:pass@localhost:9999/dbname/schema?timeout=1000`, `snowflake`, `user:pass@localhost:9999/dbname/schema?timeout=1000`},
 
 		{`rs://user:pass@amazon.com/dbname`, `postgres`, `postgres://user:pass@amazon.com:5439/dbname`}, // 61
+
+		{`mylogin:/`, `mylogin`, `/`}, // 62
+		{`mylogin:client_prod/test`, `mylogin`, `client_prod/test`},
+		{`mylogin:/home/me/.mylogin.cnf//client_prod/test`, `mylogin`, `/home/me/.mylogin.cnf//client_prod/test`},
+		{`mylogin:/home/me/.mylogin.cnf//client_prod/test?loc=UTC&parseTime=true&time_zone=%27%2B0%3A00%27`, `mylogin`, `/home/me/.mylogin.cnf//client_prod/test?loc=UTC&parseTime=true&time_zone=%27%2B0%3A00%27`},
+		// Options are ordered
+		{`mylogin:/home/me/.mylogin.cnf//client_prod/test?parseTime=true&loc=UTC&time_zone=%27%2B0%3A00%27`, `mylogin`, `/home/me/.mylogin.cnf//client_prod/test?loc=UTC&parseTime=true&time_zone=%27%2B0%3A00%27`},
+		// ":" => "%3A"
+		{`mylogin:/home/me/.mylogin.cnf//client_prod/test?loc=UTC&parseTime=true&time_zone=%27%2B0:00%27`, `mylogin`, `/home/me/.mylogin.cnf//client_prod/test?loc=UTC&parseTime=true&time_zone=%27%2B0%3A00%27`},
 	}
 
 	for i, test := range tests {

--- a/dsn.go
+++ b/dsn.go
@@ -302,6 +302,18 @@ func GenMyMySQL(u *URL) (string, error) {
 	return dsn, nil
 }
 
+// GenMyMySQL generates a mylogin-driver DSN for MySQL from the passed URL.
+func GenMylogin(u *URL) (string, error) {
+	if len(u.URL.Opaque) > 0 {
+		// See GenOpaque
+		return u.Opaque + genQueryOptions(u.Query()), nil
+	}
+	if len(u.Path) > 0 {
+		return u.Path + genQueryOptions(u.Query()), nil
+	}
+	return "", ErrMissingPath
+}
+
 // GenOracle generates a ora DSN from the passed URL.
 func GenOracle(u *URL) (string, error) {
 	// create dsn

--- a/scheme.go
+++ b/scheme.go
@@ -64,6 +64,7 @@ func BaseSchemes() []Scheme {
 		{"redshift", GenFromURL("postgres://localhost:5439/"), 0, false, []string{"rs"}, "postgres"},
 		{"tidb", GenMySQL, 0, false, nil, "mysql"},
 		{"vitess", GenMySQL, 0, false, []string{"vt"}, "mysql"},
+		{"mylogin", GenMylogin, 0, true, []string{"ml"}, ""},
 
 		// testing
 		{"spanner", GenScheme("spanner"), 0, false, []string{"gs", "google", "span"}, ""},


### PR DESCRIPTION
Add support for [`github.com/dolmen-go/mylogin-driver`](https://github.com/dolmen-go/mylogin-driver/), a wrapper around `github.com/go-sql-drivers/mysql` that allows to load credentials from the obfuscated `~/.mylogin.cnf` file.

I have not reformatted README.md to show clearly what changed in the diff. I will add a cleanup commit on request.