### PR TITLE
add goracle as another Oracle driver

### DIFF
--- a/dburl.go
+++ b/dburl.go
@@ -48,6 +48,7 @@
 //   mssql://user:pass@remote-host.com/instance/dbname
 //   ms://user:pass@remote-host.com:port/instance/dbname?keepAlive=10
 //   oracle://user:pass@somehost.com/oracledb
+//   goracle://user:pass@somehost.com/oracledb
 //   sap://user:pass@localhost/dbname
 //   sqlite:/path/to/file.db
 //   file:myfile.sqlite3?loc=auto
@@ -63,6 +64,7 @@
 //   Microsoft SQL Server (mssql) | ms, sqlserver
 //   MySQL (mysql)                | my, mariadb, maria, percona, aurora
 //   Oracle (ora)                 | or, oracle, oci8, oci
+//   Oracle (goracle)             | goracle
 //   PostgreSQL (postgres)        | pg, postgresql, pgsql
 //   SQLite3 (sqlite3)            | sq, sqlite, file
 //   -----------------------------|-------------------------------------------
@@ -108,6 +110,7 @@
 //   Microsoft SQL Server (mssql) | github.com/denisenkom/go-mssqldb
 //   MySQL (mysql)                | github.com/go-sql-driver/mysql
 //   Oracle (ora)                 | gopkg.in/rana/ora.v4
+//   Oracle (goracle)             | gopkg.in/goracle.v2
 //   PostgreSQL (postgres)        | github.com/lib/pq
 //   SQLite3 (sqlite3)            | github.com/mattn/go-sqlite3
 //   -----------------------------|-------------------------------------------------

--- a/dburl_test.go
+++ b/dburl_test.go
@@ -115,20 +115,21 @@ func TestParse(t *testing.T) {
 		{`sq://:memory:?loc=auto`, `sqlite3`, `:memory:?loc=auto`},
 
 		{`oracle://user:pass@localhost/xe.oracle.docker`, `ora`, `user/pass@localhost/xe.oracle.docker`}, // 41
+		{`goracle://user:pass@localhost/xe.oracle.docker`, `goracle`, `user/pass@localhost/xe.oracle.docker`},
 
-		{`presto://host:8001/`, `presto`, `http://user@host:8001?catalog=default`}, // 42
+		{`presto://host:8001/`, `presto`, `http://user@host:8001?catalog=default`}, // 43
 		{`presto://host/catalogname/schemaname`, `presto`, `http://user@host:8080?catalog=catalogname&schema=schemaname`},
 		{`prs://admin@host/catalogname`, `presto`, `https://admin@host:8443?catalog=catalogname`},
 		{`prestodbs://admin:pass@host:9998/catalogname`, `presto`, `https://admin:pass@host:9998?catalog=catalogname`},
 
-		{`ca://host`, `cql`, `host:9042`}, // 46
+		{`ca://host`, `cql`, `host:9042`}, // 47
 		{`cassandra://host:9999`, `cql`, `host:9999`},
 		{`scy://user@host:9999`, `cql`, `host:9999?username=user`},
 		{`scylla://user@host:9999?timeout=1000`, `cql`, `host:9999?timeout=1000&username=user`},
 		{`datastax://user:pass@localhost:9999/?timeout=1000`, `cql`, `localhost:9999?password=pass&timeout=1000&username=user`},
 		{`ca://user:pass@localhost:9999/dbname?timeout=1000`, `cql`, `localhost:9999?keyspace=dbname&password=pass&timeout=1000&username=user`},
 
-		{`ig://host`, `ignite`, `tcp://host:10800`}, // 52
+		{`ig://host`, `ignite`, `tcp://host:10800`}, // 53
 		{`ignite://host:9999`, `ignite`, `tcp://host:9999`},
 		{`gridgain://user@host:9999`, `ignite`, `tcp://host:9999?username=user`},
 		{`ig://user@host:9999?timeout=1000`, `ignite`, `tcp://host:9999?timeout=1000&username=user`},
@@ -139,7 +140,7 @@ func TestParse(t *testing.T) {
 		{`sf://user@host:9999/dbname/schema?timeout=1000`, `snowflake`, `user@host:9999/dbname/schema?timeout=1000`},
 		{`sf://user:pass@localhost:9999/dbname/schema?timeout=1000`, `snowflake`, `user:pass@localhost:9999/dbname/schema?timeout=1000`},
 
-		{`rs://user:pass@amazon.com/dbname`, `postgres`, `postgres://user:pass@amazon.com:5439/dbname`}, // 61
+		{`rs://user:pass@amazon.com/dbname`, `postgres`, `postgres://user:pass@amazon.com:5439/dbname`}, // 62
 	}
 
 	for i, test := range tests {

--- a/scheme.go
+++ b/scheme.go
@@ -55,6 +55,7 @@ func BaseSchemes() []Scheme {
 		{"mssql", GenSQLServer, 0, false, []string{"sqlserver"}, ""},
 		{"mysql", GenMySQL, ProtoTCP | ProtoUDP | ProtoUnix, false, []string{"mariadb", "maria", "percona", "aurora"}, ""},
 		{"ora", GenOracle, 0, false, []string{"oracle", "oci8", "oci"}, ""},
+		{"goracle", GenOracle, 0, false, []string{"goracle"}, ""},
 		{"postgres", GenPostgres, ProtoUnix, false, []string{"pg", "postgresql", "pgsql"}, ""},
 		{"sqlite3", GenOpaque, 0, true, []string{"sqlite", "file"}, ""},
 


### PR DESCRIPTION
goracle.v2 is better than rana/ora.v4, supports sql.Out thus allows clean stored procedure support.
This is the first step to include support into xo.