### PR TITLE
Do not throw an error for SnowflakeDB DSNs without a database

### DIFF
--- a/dburl.go
+++ b/dburl.go
@@ -202,6 +202,9 @@ const (
 
 	// ErrMissingPath is the missing path error.
 	ErrMissingPath Error = "missing path"
+
+	// ErrMissingUser is the missing user error.
+	ErrMissingUser Error = "missing user"
 )
 
 // Open takes a urlstr like "protocol+transport://user:pass@host/dbname?option1=a&option2=b"

--- a/dburl_test.go
+++ b/dburl_test.go
@@ -43,8 +43,8 @@ func TestBadParse(t *testing.T) {
 		{`pg+unix:./path/to/socket`, ErrRelativePathNotSupported},
 		{`snowflake://`, ErrMissingHost},
 		{`sf://`, ErrMissingHost},
-		{`snowflake://account`, ErrMissingPath},
-		{`sf://account`, ErrMissingPath},
+		{`snowflake://account`, ErrMissingUser},
+		{`sf://account`, ErrMissingUser},
 	}
 
 	for i, test := range tests {
@@ -150,13 +150,12 @@ func TestParse(t *testing.T) {
 		{`ig://user:pass@localhost:9999/?timeout=1000`, `ignite`, `tcp://localhost:9999?password=pass&timeout=1000&username=user`, ``},
 		{`ig://user:pass@localhost:9999/dbname?timeout=1000`, `ignite`, `tcp://localhost:9999/dbname?password=pass&timeout=1000&username=user`, ``},
 
-		{`snowflake://host/dbname/schema`, `snowflake`, `host/dbname/schema`, ``}, // 65
 		{`sf://user@host:9999/dbname/schema?timeout=1000`, `snowflake`, `user@host:9999/dbname/schema?timeout=1000`, ``},
 		{`sf://user:pass@localhost:9999/dbname/schema?timeout=1000`, `snowflake`, `user:pass@localhost:9999/dbname/schema?timeout=1000`, ``},
 
-		{`rs://user:pass@amazon.com/dbname`, `postgres`, `postgres://user:pass@amazon.com:5439/dbname`, ``}, // 68
+		{`rs://user:pass@amazon.com/dbname`, `postgres`, `postgres://user:pass@amazon.com:5439/dbname`, ``}, // 67
 
-		{`ve://user:pass@vertica-host/dbvertica?tlsmode=server-strict`, `vertica`, `vertica://user:pass@vertica-host:5433/dbvertica?tlsmode=server-strict`, ``}, // 69
+		{`ve://user:pass@vertica-host/dbvertica?tlsmode=server-strict`, `vertica`, `vertica://user:pass@vertica-host:5433/dbvertica?tlsmode=server-strict`, ``}, // 68
 	}
 
 	for i, test := range tests {

--- a/dsn.go
+++ b/dsn.go
@@ -566,22 +566,21 @@ func GenSnowflake(u *URL) (string, error) {
 	if host == "" {
 		return "", ErrMissingHost
 	}
-	if dbname == "" {
-		return "", ErrMissingPath
-	}
 	if port != "" {
 		port = ":" + port
 	}
 
 	// add user/pass
-	var user string
-	if u.User != nil {
-		user = u.User.Username()
-		if pass, _ := u.User.Password(); pass != "" {
-			user += ":" + pass
-		}
-		user += "@"
+	if u.User == nil {
+		return "", ErrMissingUser
 	}
+	var user string
+
+	user = u.User.Username()
+	if pass, _ := u.User.Password(); pass != "" {
+		user += ":" + pass
+	}
+	user += "@"
 
 	return user + host + port + "/" + dbname + genQueryOptions(u.Query()), nil
 }


### PR DESCRIPTION
Hey there. I was playing around with usql and noticed that dburl throws an error for a missing database in the dsn. Snowflake does not require a database for the initial connection: the database can be chosen and switched during the connection. I'm submitting this PR to allow connecting without specifying a database. I've done some smoke testing to show that this works:

```
mbp:usql pbennes$ ./usql 'sf://admin:password@test/?insecureMode=true'
Connected with driver snowflake (<unknown>)
Type "help" for help.

sf:admin@test=> select 1;
 1 
---
 1 
(1 row)

sf:admin@test=> show databases like 'SNOWFLAKE';
 created_on                  | name      | is_default | is_current | origin                  | owner | comment | options | retention_time 
-----------------------------+-----------+------------+------------+-------------------------+-------+---------+---------+----------------
 2018-08-14T16:05:09.3-04:00 | SNOWFLAKE | N          | N          | SNOWFLAKE.ACCOUNT_USAGE |       |         |         | 1              
(1 row)

sf:admin@test=> use database snowflake;
error: snowflake: no RowsAffected available after DDL statement
sf:admin@test=> show databases like 'SNOWFLAKE';
 created_on                  | name      | is_default | is_current | origin                  | owner | comment | options | retention_time 
-----------------------------+-----------+------------+------------+-------------------------+-------+---------+---------+----------------
 2018-08-14T16:05:09.3-04:00 | SNOWFLAKE | N          | Y          | SNOWFLAKE.ACCOUNT_USAGE |       |         |         | 1              
(1 row)

sf:admin@test=> ^D
mbp:usql pbennes$ 
```