### PR TITLE
Adding Trino URL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ supported out of the box:
 | SAP ASE (tds)                   | ax, ase, sapase                          |
 | SAP HANA (hdb)                  | sa, saphana, sap, hana                   |
 | Snowflake (snowflake)           | sf                                       |
+| Trino (trino)                   | tr, trino, trinos, trs                   |
 | Vertica (vertica)               | ve                                       |
 | VoltDB (voltdb)                 | vo, volt, vdb                            |
 <!-- END SCHEME TABLE -->
@@ -206,6 +207,7 @@ to be imported:
 | SAP ASE (tds)                   | [github.com/thda/tds](https://github.com/thda/tds)                                          |
 | SAP HANA (hdb)                  | [github.com/SAP/go-hdb/driver](https://github.com/SAP/go-hdb)                               |
 | Snowflake (snowflake)           | [github.com/snowflakedb/gosnowflake](https://github.com/snowflakedb/gosnowflake)            |
+| Trino (trino)                   | [github.com/trinodb/trino-go-client/trino](https://github.com/trinodb/trino-go-client) |
 | Vertica (vertica)               | [github.com/vertica/vertica-sql-go](https://github.com/vertica/vertica-sql-go)              |
 | VoltDB (voltdb)                 | [github.com/VoltDB/voltdb-client-go/voltdbclient](github.com/VoltDB/voltdb-client-go])      |
 <!-- END DRIVER TABLE -->

--- a/dburl.go
+++ b/dburl.go
@@ -111,6 +111,7 @@
 //	 SAP ASE (tds)                   | ax, ase, sapase
 //	 SAP HANA (hdb)                  | sa, saphana, sap, hana
 //	 Snowflake (snowflake)           | sf
+//	 Trino (trino)                   | tr, trino, trinos, trs
 //	 Vertica (vertica)               | ve
 //	 VoltDB (voltdb)                 | vo, volt, vdb
 //
@@ -167,6 +168,7 @@
 //	 SAP ASE (tds)                   | github.com/thda/tds
 //	 SAP HANA (hdb)                  | github.com/SAP/go-hdb/driver
 //	 Snowflake (snowflake)           | github.com/snowflakedb/gosnowflake
+//	 Trino (trino)                   | github.com/trinodb/trino-go-client/trino
 //	 Vertica (vertica)               | github.com/vertica/vertica-sql-go
 //	 VoltDB (voltdb)                 | github.com/VoltDB/voltdb-client-go/voltdbclient
 //

--- a/dburl_test.go
+++ b/dburl_test.go
@@ -175,6 +175,10 @@ func TestParse(t *testing.T) {
 		{`gr://username:password@host/ORCL`, `godror`, `username/password@//host/ORCL`, ``},
 		{`gr://username:password@sales-server:1521/sales.us.acme.com`, `godror`, `username/password@//sales-server:1521/sales.us.acme.com`, ``},
 		{`godror://username:password@sales-server.us.acme.com/sales.us.oracle.com`, `godror`, `username/password@//sales-server.us.acme.com/sales.us.oracle.com`, ``},
+
+		{`trino://host:8001/`, `trino`, `http://user@host:8001?catalog=default`, ``}, // 85
+		{`trino://host/catalogname/schemaname`, `trino`, `http://user@host:8080?catalog=catalogname&schema=schemaname`, ``},
+		{`trs://admin@host/catalogname`, `trino`, `https://admin@host:8443?catalog=catalogname`, ``},
 	}
 	for i, test := range tests {
 		u, err := Parse(test.s)

--- a/scheme.go
+++ b/scheme.go
@@ -95,6 +95,7 @@ func BaseSchemes() []Scheme {
 		{"snowflake", GenSnowflake, 0, false, []string{"sf"}, ""},
 		{"spanner", GenSpanner, 0, false, []string{"sp"}, ""},
 		{"tds", GenFromURL("http://localhost:5000/"), 0, false, []string{"ax", "ase", "sapase"}, ""},
+		{"trino", GenPresto, 0, false, []string{"trino", "trinos", "trs"}, ""},
 		{"vertica", GenFromURL("vertica://localhost:5433/"), 0, false, nil, ""},
 		{"voltdb", GenVoltDB, 0, false, []string{"volt", "vdb"}, ""},
 	}


### PR DESCRIPTION
PrestoSQL got renamed to Trino, clearing up the confusion between PrestoDB and PrestoSQL. This PR adds Trino as a separate scheme.

I reused the `GenPresto` function since right now the URL parsing is exactly the same.

More details about the rename: https://trino.io/blog/2020/12/27/announcing-trino.html