### PR TITLE
added schemes gcppostgres and awspostgres from gocloud.dev

### DIFF
--- a/dburl.go
+++ b/dburl.go
@@ -74,7 +74,7 @@
 //   Microsoft SQL Server (mssql)    | ms, sqlserver
 //   MySQL (mysql)                   | my, mariadb, maria, percona, aurora
 //   Oracle Database (oracle)        | or, ora, oci, oci8, odpi, odpi-c
-//   PostgreSQL (postgres)           | pg, postgresql, pgsql
+//   PostgreSQL (postgres)           | pg, postgresql, pgsql, gcppostgres, awspostgres
 //   SQLite3 (sqlite3)               | sq, sqlite, file
 //   --------------------------------|--------------------------------------------
 //   Amazon Redshift (redshift)      | rs [postgres]

--- a/scheme.go
+++ b/scheme.go
@@ -55,7 +55,7 @@ func BaseSchemes() []Scheme {
 		{"mssql", GenSQLServer, 0, false, []string{"sqlserver"}, ""},
 		{"mysql", GenMySQL, ProtoTCP | ProtoUDP | ProtoUnix, false, []string{"mariadb", "maria", "percona", "aurora"}, ""},
 		{"oracle", GenScheme("oracle"), 0, false, []string{"ora", "oci", "oci8", "odpi", "odpi-c"}, ""},
-		{"postgres", GenPostgres, ProtoUnix, false, []string{"pg", "postgresql", "pgsql"}, ""},
+		{"postgres", GenPostgres, ProtoUnix, false, []string{"pg", "postgresql", "pgsql", "gcppostgres", "awspostgres"}, ""},
 		{"sqlite3", GenOpaque, 0, true, []string{"sqlite", "file"}, ""},
 
 		// wire compatibles


### PR DESCRIPTION
Adds `gcppostgres` and `awspostgres` schemes to support for https://github.com/xo/usql/issues/133

pre-requisite for https://github.com/xo/usql/pull/163