### PR TITLE
Add azuresql scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ supported out of the box:
 | Oracle Database (oracle)         | or, ora, oracle, oci, oci8, odpi, odpi-c |
 | PostgreSQL (postgres)            | pg, postgresql, pgsql                    |
 | SQLite3 (sqlite3)                | sq, sqlite, file                         |
-| Microsoft SQL Server (sqlserver) | ms, mssql                                |
+| Microsoft SQL Server (sqlserver) | ms, mssql, azuresql                      |
 |                                  |                                          |
 | Amazon Redshift (redshift)       | rs [postgres]                            |
 | CockroachDB (cockroachdb)        | cr, cockroach, crdb, cdb [postgres]      |

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ to be imported:
 | Oracle Database (oracle)         | [github.com/sijms/go-ora](https://github.com/sijms/go-ora)                                                     |
 | PostgreSQL (postgres)            | [github.com/lib/pq](https://github.com/lib/pq)                                                                 |
 | SQLite3 (sqlite3)                | [github.com/mattn/go-sqlite3](https://github.com/mattn/go-sqlite3)                                             |
-| Microsoft SQL Server (sqlserver) | [github.com/denisenkom/go-mssqldb](https://github.com/denisenkom/go-mssqldb)                                   |
+| Microsoft SQL Server (sqlserver) | [github.com/microsoft/go-mssqldb](https://github.com/microsoft/go-mssqldb)                                   |
 |                                  |                                                                                                                |
 | Amazon Redshift (redshift)       | [github.com/lib/pq](https://github.com/lib/pq)                                                                 |
 | CockroachDB (cockroachdb)        | [github.com/lib/pq](https://github.com/lib/pq)                                                                 |
@@ -250,7 +250,7 @@ import (
 	"fmt"
 	"log"
 
-	_ "github.com/denisenkom/go-mssqldb"
+	_ "github.com/microsoft/go-mssqldb"
 	"github.com/xo/dburl"
 )
 

--- a/_example/example.go
+++ b/_example/example.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	_ "github.com/denisenkom/go-mssqldb"
+	_ "github.com/microsoft/go-mssqldb"
 	"github.com/xo/dburl"
 )
 

--- a/dburl.go
+++ b/dburl.go
@@ -71,7 +71,7 @@
 //
 //   Database (scheme/driver)         | Protocol Aliases [real driver]
 //   ---------------------------------|--------------------------------------------
-//   Microsoft SQL Server (sqlserver) | ms, mssql
+//   Microsoft SQL Server (sqlserver) | ms, mssql, azuresql
 //   MySQL (mysql)                    | my, mariadb, maria, percona, aurora
 //   Oracle Database (oracle)         | or, ora, oci, oci8, odpi, odpi-c
 //   PostgreSQL (postgres)            | pg, postgresql, pgsql

--- a/dburl.go
+++ b/dburl.go
@@ -132,7 +132,7 @@
 //
 //   Database (scheme/driver)         | Package
 //	----------------------------------|-------------------------------------------------
-//	 Microsoft SQL Server (sqlserver) | github.com/denisenkom/go-mssqldb
+//	 Microsoft SQL Server (sqlserver) | github.com/microsoft/go-mssqldb
 //	 MySQL (mysql)                    | github.com/go-sql-driver/mysql
 //	 Oracle Database (oracle)         | github.com/sijms/go-ora/v2
 //	 PostgreSQL (postgres)            | github.com/lib/pq

--- a/scheme.go
+++ b/scheme.go
@@ -53,7 +53,7 @@ func BaseSchemes() []Scheme {
 		{"oracle", GenFromURL("oracle://localhost:1521"), 0, false, []string{"ora", "oci", "oci8", "odpi", "odpi-c"}, ""},
 		{"postgres", GenPostgres, TransportUnix, false, []string{"pg", "postgresql", "pgsql"}, ""},
 		{"sqlite3", GenOpaque, 0, true, []string{"sqlite", "file"}, ""},
-		{"sqlserver", GenSqlserver, 0, false, []string{"ms", "mssql"}, ""},
+		{"sqlserver", GenSqlserver, 0, false, []string{"ms", "mssql", "azuresql"}, ""},
 		// wire compatibles
 		{"cockroachdb", GenFromURL("postgres://localhost:26257/?sslmode=disable"), 0, false, []string{"cr", "cockroach", "crdb", "cdb"}, "postgres"},
 		{"memsql", GenMysql, 0, false, nil, "mysql"},


### PR DESCRIPTION
## Description

The whole point for adding `azuresql` alias is that recently Microsoft took the ownership for `go-mssqldb` driver, and by chance they also implemented Azure AD authentication, which implies that on the application side we:
- imported a subpackage `azuread`;
- use `azuresql` as a scheme.

The rest stays the same, so it seems to be a low hanging fruit.

Reference link: https://github.com/microsoft/go-mssqldb#azure-active-directory-authentication