### PR TITLE
fix spanner dsn

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -534,7 +534,7 @@ func GenSpanner(u *URL) (string, error) {
 	if instance == "" || dbname == "" {
 		return "", ErrMissingPath
 	}
-	return fmt.Sprintf(`project/%s/instances/%s/databases/%s`, project, instance, dbname), nil
+	return fmt.Sprintf(`projects/%s/instances/%s/databases/%s`, project, instance, dbname), nil
 }
 
 // GenSqlserver generates a sqlserver DSN from the passed URL.


### PR DESCRIPTION
Fix the output string in  `GenSpanner`  method for creating a Spanner DSN. The current implementation of  GenSpanner  in `xo/dburl` generates an incorrect output string when creating a Cloud Spanner DSN. 

Specifically, the generated string includes a typo in the  `project/`  prefix, which should be  `projects/` . 
This pull request fixes the issue by correcting the typo in the output string, so that it conforms to the expected format. 
The fix has been tested against a Cloud Spanner instance and verified to work correctly. 

Please let me know if there's anything else I can do to help with this contribution. Thank you!

reference: 
- [Cloud Spanner’s Go database/sql driver is now Generally Available | Google Cloud Blog](https://cloud.google.com/blog/topics/developers-practitioners/golangs-databasesql-driver-support-cloud-spanner-now-generally-available?hl=en)