### PR TITLE
add support for Ingres (Vector) DSN

### DIFF
--- a/dburl_test.go
+++ b/dburl_test.go
@@ -206,6 +206,15 @@ func TestParse(t *testing.T) {
 		{`bend://user:pass@localhost/instance_name?sslmode=disabled&warehouse=wh`, `databend`, `bend://user:pass@localhost/instance_name?sslmode=disabled&warehouse=wh`, ``},
 		{`databend://user:pass@localhost/instance_name?tenant=tn&warehouse=wh`, `databend`, `databend://user:pass@localhost/instance_name?tenant=tn&warehouse=wh`, ``},
 		{`flightsql://user:pass@localhost?timeout=3s&token=foobar&tls=enabled`, `flightsql`, `flightsql://user:pass@localhost?timeout=3s&token=foobar&tls=enabled`, ``},
+		{`ingres://mydb`, `ingres`, `mydb`, ``},
+		{`ingres://node1/mydb`, `ingres`, `node1::mydb`, ``},
+		{`ingres://node1/mydb/s1`, `ingres`, `node1::mydb/s1`, ``},
+		{`ingres://node1/mydb/s1/s2`, `ingres`, `node1::mydb/s1`, ``},
+		{`ingres://`, `ingres`, `iidbdb`, ``},
+		{`ingres://user:pass@mydb`, `ingres`, `mydb?password=pass&username=user`, ``},
+                {`ingres://user:pass@node1/mydb`, `ingres`, `node1::mydb?password=pass&username=user`, ``},
+		{`vector://mydb`, `ingres`, `mydb`, ``},
+		{`actianx://mydb`, `ingres`, `mydb`, ``},
 	}
 	for i, test := range tests {
 		u, err := Parse(test.s)

--- a/scheme.go
+++ b/scheme.go
@@ -98,6 +98,7 @@ func BaseSchemes() []Scheme {
 		{"trino", GenPresto, 0, false, []string{"trino", "trinos", "trs"}, ""},
 		{"vertica", GenFromURL("vertica://localhost:5433/"), 0, false, nil, ""},
 		{"voltdb", GenVoltdb, 0, false, []string{"volt", "vdb"}, ""},
+		{"ingres", GenIngres, 0, false, []string{"vector", "actianx"}, ""},
 	}
 }
 


### PR DESCRIPTION
Add DSN generation for Ingres (Vector).

Full DSN has format like: ingres://user:pass@vnode/dbname/server_class
Simplest DSN: ingres://dbname - uses current user from the system.
