### PR TITLE
Use gocosmos as Go driver name for cosmosdb

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -193,7 +193,7 @@ func GenCosmos(u *URL) (string, string, error) {
 	if dbname != "" {
 		q.Set("Db", dbname)
 	}
-	return genOptionsOdbc(q, true, nil, nil), "", nil
+	return genOptionsOdbc(q, true, nil, nil), "gocosmos", nil
 }
 
 // GenDatabend generates a databend DSN from the passed URL.

--- a/scheme.go
+++ b/scheme.go
@@ -173,7 +173,7 @@ func BaseSchemes() []Scheme {
 		{
 			"cosmos",
 			GenCosmos, 0, false,
-			[]string{"cm"},
+			[]string{"cm", "gocosmos"},
 			"",
 		},
 		{


### PR DESCRIPTION
Use gocosmos as Go driver name for cosmosdb

Fixes in part https://github.com/xo/usql/issues/511 .
The fix could be in usql but this way other users
of dburl also benefits. gocosmos is the driver name in both github.com/btnguyen2k/gocosmos and github.com/microsoft/gocosmos .

Testing Done: with usql compiled with fix for stripping trailing semicolon:

![image](https://github.com/user-attachments/assets/b44e274e-bb4d-42be-beb5-9982a3018aba)
